### PR TITLE
Linux port

### DIFF
--- a/GPXLab/gpx_model/actfile.cpp
+++ b/GPXLab/gpx_model/actfile.cpp
@@ -21,6 +21,11 @@
 #include <time.h>
 #include "actfile.h"
 
+#if !defined(_WIN32) && !defined(_WIN64)
+// stricmp is Windows-specific, strcasecmp is POSIX-specific, both are not C stndard
+  #define stricmp strcasecmp
+#endif
+
 extern "C" {
 #include "uxmlpars.h"
 }

--- a/GPXLab/gpx_model/gpxfile.cpp
+++ b/GPXLab/gpx_model/gpxfile.cpp
@@ -15,11 +15,19 @@
  *   along with This program. If not, see <http://www.gnu.org/licenses/>.   *
  ****************************************************************************/
 
+
 #include <stdlib.h>
 #include <string.h>
 #include <string>
 #include <time.h>
 #include "gpxfile.h"
+
+#if !defined(_WIN32) && !defined(_WIN64)
+// stricmp is Windows-specific, strcasecmp is POSIX-specific, both are not C stndard
+  #define stricmp strcasecmp
+#endif
+
+
 
 extern "C" {
 #include "uxmlpars.h"

--- a/GPXLab/gpx_model/gpxfile.cpp
+++ b/GPXLab/gpx_model/gpxfile.cpp
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <string>
 #include <time.h>
+#include <sstream>
+#include <locale>
 #include "gpxfile.h"
 
 #if !defined(_WIN32) && !defined(_WIN64)
@@ -607,10 +609,16 @@ static void tagAttribute(void* pXml, char* pTag, char *pAttribute, char* pConten
         case PARSING_TRKPT:
             if (stricmp(pTag, "trkpt") == 0)
             {
+                // atof() function is locale-aware, at least on linux
+                // To correctly parse GPX on any locale (e.g. where comma is decimal separator)
+                // , need to suppress the locale while parsing. Do it C++ way
+                std::istringstream istr(pContent);
+                istr.imbue(std::locale("C"));
+
                 if (stricmp(pAttribute, "lat") == 0)
-                    gpxm->trk.back().trkseg.back().trkpt.back().latitude = atof(pContent);
+                    istr >> gpxm->trk.back().trkseg.back().trkpt.back().latitude;
                 else if (stricmp(pAttribute, "lon") == 0)
-                    gpxm->trk.back().trkseg.back().trkpt.back().longitude = atof(pContent);
+                    istr >> gpxm->trk.back().trkseg.back().trkpt.back().longitude;
             }
             break;
 

--- a/GPXLab/widgets/qtablewidgetpoints.cpp
+++ b/GPXLab/widgets/qtablewidgetpoints.cpp
@@ -20,7 +20,7 @@
 #include <QHeaderView>
 #include <QDateTime>
 #include "qtablewidgetpoints.h"
-#include "QUtils.h"
+#include "qutils.h"
 #include "pointeditcommand.h"
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix to compile/run on linux.
Ubuntu 16.06, gcc 5.4, Qt 5.7, Qt Creator 4.0.2

Please note: second commit (locale-aware atof() ) may fix Windows also in some locales. 
Without it, App rounded lat/lon to integers even in Windows .exe run under Wine.
