### PR TITLE
Added common files required for distribution

### DIFF
--- a/pkg/appdata.xml
+++ b/pkg/appdata.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+	<id>gpxlab.desktop</id>
+	<metadata_license>MIT</metadata_license>
+	<project_license>GPL-3.0</project_license>
+
+	<name>GPXLab</name>
+	<summary>Program to show and manipulate GPS tracks</summary>
+	<description>
+		<p>GPXLab is an application to display and manage GPS tracks previously recorded with a GPS tracker.</p>
+
+		<p>Features:</p>
+		<ul>
+			<li>Support opening GPX (v1.0 or v1.1), NMEA and SpoQ files.</li>
+			<li>Combine several tracks into one single GPX file.</li>
+			<li>Rearrange the tracks (move/add/delete).</li>
+			<li>Modify the meta data of the GPX file and of any tracks inside the file.</li>
+			<li>Get altitude data from the SRTM database.</li>
+			<li>Show statistic information about the summarized tracks and about a single track.</li>
+			<li>Show a map of all tracks.</li>
+			<li>Show an altitude and a speed diagram.</li>
+			<li>Show a list of the track points.</li>
+		</ul>
+	</description>
+
+	<screenshots>
+		<screenshot type="default">
+			<image>https://raw.githubusercontent.com/BourgeoisLab/GPXLab/master/doc/demo.png</image>
+		</screenshot>
+	</screenshots>
+
+	<categories>
+		<category>Graphics</category>
+		<category>Viewer</category>
+	</categories>
+
+	<url type="homepage">https://github.com/BourgeoisLab/GPXLab</url>
+
+	<launchable type="desktop-id">gpxlab.desktop</launchable>
+
+	<provides>
+		<binary>gpxlab</binary>
+	</provides>
+
+	<mimetypes>
+		<mimetype>application/gpx+xml</mimetype>
+		<mimetype>application/vnd.nmea.nmea</mimetype>
+	</mimetypes>
+</component>

--- a/pkg/gpxlab.desktop
+++ b/pkg/gpxlab.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=GPXLab
+Comment=Program to show and manipulate GPS tracks
+Exec=gpxlab %F
+Icon=gpxlab
+Terminal=false
+Type=Application
+Categories=Graphics;Viewer;Maps;Qt;
+MimeType=application/gpx+xml;application/vnd.nmea.nmea;

--- a/pkg/gpxlab.xml
+++ b/pkg/gpxlab.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+	<mime-type type="application/gpx+xml">
+		<comment>GPS Exchange Format</comment>
+		<sub-class-of type="application/xml"/>
+		<generic-icon name="application-xml"/>
+		<glob pattern="*.gpx"/>
+	</mime-type>
+	<mime-type type="application/vnd.nmea.nmea">
+		<comment>NMEA 0183 data</comment>
+		<sub-class-of type="text/plain"/>
+		<generic-icon name="text-plain"/>
+		<glob pattern="*.nmea"/>
+	</mime-type>
+</mime-info>


### PR DESCRIPTION
While maintaining AUR packages for GPXLab ([gpxlab](https://aur.archlinux.org/packages/gpxlab/) and [gpxlab-git](https://aur.archlinux.org/packages/gpxlab-git/)), I miss some useful files required for distribution packages:
- shared mime info file (gpxlab.xml)
- desktop file (gpxlab.desktop)
- freedesktop appstream info (appdata.xml)

The only thing I can't find anywhere - Mime Type for SpoQ files.