### PR TITLE
Fix saving GPX file

### DIFF
--- a/GPXLab/gpx_model/actfile.cpp
+++ b/GPXLab/gpx_model/actfile.cpp
@@ -266,13 +266,13 @@ static void tagContent(void* pXml, char* pTag, char* pContent)
         //    gTrkseg->trkpt.back().altitude = 0;
         //else
         if (strcmp(pTag, "latitude") == 0)
-            gTrkseg->trkpt.back().latitude = UTILS_atof(pContent);
+            gTrkseg->trkpt.back().latitude = atof(pContent);
         else if (strcmp(pTag, "longitude") == 0)
-            gTrkseg->trkpt.back().longitude = UTILS_atof(pContent);
+            gTrkseg->trkpt.back().longitude = atof(pContent);
         else if (strcmp(pTag, "altitude") == 0)
-            gTrkseg->trkpt.back().altitude = UTILS_atof(pContent);
+            gTrkseg->trkpt.back().altitude = atof(pContent);
         else if (strcmp(pTag, "speed") == 0)
-            gTrkseg->trkpt.back().speed = (float)UTILS_atof(pContent);
+            gTrkseg->trkpt.back().speed = (float)atof(pContent);
         else if (strcmp(pTag, "heartrate") == 0 || strcmp(pTag, "heart_x0020_rate") == 0)
             gTrkseg->trkpt.back().extensionsGarmin.heartrate = atoi(pContent);
         else if (strcmp(pTag, "intervaltime") == 0 || strcmp(pTag, "interval_x0020_time") == 0)
@@ -358,9 +358,21 @@ GPX_model::retCode_e ACTFile::load(ifstream* fp, GPX_model* gpxm)
     // add track
     gpxm->trk.push_back(trk);
 
+    // set timezone temporary to UTC
+    char *tz = getenv("TZ");
+    UTILS_setenv("TZ", "UTC");
+    tzset();
+
     // parse file
     if (UXML_parseFile(&uXML) != 0)
         return GPX_model::GPXM_ERR_FAILED;
+
+    // change back timezone
+    if (tz)
+        UTILS_setenv("TZ", tz);
+    else
+        UTILS_unsetenv("TZ");
+    tzset();
 
     // update track
     gpxm->updateTrack(gpxm->trk.back());

--- a/GPXLab/gpx_model/gpxfile.cpp
+++ b/GPXLab/gpx_model/gpxfile.cpp
@@ -420,16 +420,16 @@ static void tagContent(void* pXml, char* pTag, char* pContent)
 
         case PARSING_TRKPT:
             if (strcmp(pTag, "ele") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().altitude = UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().altitude = atof(pContent);
             else if (strcmp(pTag, "time") == 0)
             {
                 gpxm->trk.back().trkseg.back().trkpt.back().timestamp = strToTime(sContent);
                 gpxm->trk.back().trkseg.back().trkpt.back().millisecond = strToMilliseconds(sContent);
             }
             else if (strcmp(pTag, "magvar") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().magvar = (float)UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().magvar = (float)atof(pContent);
             else if (strcmp(pTag, "geoidheight") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().geoidheight = (float)UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().geoidheight = (float)atof(pContent);
             else if (strcmp(pTag, "name") == 0)
                 gpxm->trk.back().trkseg.back().trkpt.back().name = sContent;
             else if (strcmp(pTag, "cmt") == 0)
@@ -447,13 +447,13 @@ static void tagContent(void* pXml, char* pTag, char* pContent)
             else if (strcmp(pTag, "sat") == 0)
                 gpxm->trk.back().trkseg.back().trkpt.back().sat = atoi(pContent);
             else if (strcmp(pTag, "hdop") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().hdop = (float)UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().hdop = (float)atof(pContent);
             else if (strcmp(pTag, "vdop") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().vdop = (float)UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().vdop = (float)atof(pContent);
             else if (strcmp(pTag, "pdop") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().pdop = (float)UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().pdop = (float)atof(pContent);
             else if (strcmp(pTag, "ageofdgpsdata") == 0)
-                gpxm->trk.back().trkseg.back().trkpt.back().ageofdgpsdata = (float)UTILS_atof(pContent);
+                gpxm->trk.back().trkseg.back().trkpt.back().ageofdgpsdata = (float)atof(pContent);
             else if (strcmp(pTag, "dgpsid") == 0)
                 gpxm->trk.back().trkseg.back().trkpt.back().dgpsid = atoi(pContent);
 
@@ -503,7 +503,7 @@ static void tagAttribute(void* pXml, char* pTag, char *pAttribute, char* pConten
             {
                 if (strcmp(pAttribute, "version") == 0)
                 {
-                    gVersion = (int)(10 * UTILS_atof(pContent));
+                    gVersion = (int)(10 * atof(pContent));
                     if (gVersion == 10)
                         xml->state = PARSING_METADATA;
                 }
@@ -521,13 +521,13 @@ static void tagAttribute(void* pXml, char* pTag, char *pAttribute, char* pConten
                 else if (strcmp(pTag, "bounds") == 0)
                 {
                     if (strcmp(pAttribute, "minlat") == 0)
-                        gpxm->metadata.bounds.minlat = UTILS_atof(pContent);
+                        gpxm->metadata.bounds.minlat = atof(pContent);
                     else if (strcmp(pAttribute, "minlon") == 0)
-                        gpxm->metadata.bounds.minlon = UTILS_atof(pContent);
+                        gpxm->metadata.bounds.minlon = atof(pContent);
                     else if (strcmp(pAttribute, "maxlat") == 0)
-                        gpxm->metadata.bounds.maxlat = UTILS_atof(pContent);
+                        gpxm->metadata.bounds.maxlat = atof(pContent);
                     else if (strcmp(pAttribute, "maxlon") == 0)
-                        gpxm->metadata.bounds.maxlon = UTILS_atof(pContent);
+                        gpxm->metadata.bounds.maxlon = atof(pContent);
                 }
             }
             break;
@@ -579,9 +579,9 @@ static void tagAttribute(void* pXml, char* pTag, char *pAttribute, char* pConten
             if (strcmp(pTag, "trkpt") == 0)
             {
                 if (strcmp(pAttribute, "lat") == 0)
-                    gpxm->trk.back().trkseg.back().trkpt.back().latitude = UTILS_atof(pContent);
+                    gpxm->trk.back().trkseg.back().trkpt.back().latitude = atof(pContent);
                 else if (strcmp(pAttribute, "lon") == 0)
-                    gpxm->trk.back().trkseg.back().trkpt.back().longitude = UTILS_atof(pContent);
+                    gpxm->trk.back().trkseg.back().trkpt.back().longitude = atof(pContent);
             }
             break;
 
@@ -994,7 +994,10 @@ static void writeMetadata(ofstream* fp, int depth, const GPX_metadataType* m)
 
 GPX_model::retCode_e GPXFile::save(ofstream* fp, const GPX_model* gpxm)
 {
-    setlocale(LC_ALL, "C");
+    // set timezone temporary to UTC
+    char *tz = getenv("TZ");
+    UTILS_setenv("TZ", "UTC");
+    tzset();
 
     writeStr(fp, "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>");
     writeStr(fp, "<gpx xmlns=\"http://www.topografix.com/GPX/1/1\" version=\"1.1\" creator=\"", false);
@@ -1125,7 +1128,12 @@ GPX_model::retCode_e GPXFile::save(ofstream* fp, const GPX_model* gpxm)
     writeExtensions(fp, 1, &gpxm->extensions);
     writeStr(fp, "</gpx>");
 
-    setlocale(LC_ALL, "");
+    // change back timezone
+    if (tz)
+        UTILS_setenv("TZ", tz);
+    else
+        UTILS_unsetenv("TZ");
+    tzset();
 
     return GPX_model::GPXM_OK;
 }

--- a/GPXLab/gpx_model/gpxfile.cpp
+++ b/GPXLab/gpx_model/gpxfile.cpp
@@ -994,6 +994,8 @@ static void writeMetadata(ofstream* fp, int depth, const GPX_metadataType* m)
 
 GPX_model::retCode_e GPXFile::save(ofstream* fp, const GPX_model* gpxm)
 {
+    setlocale(LC_ALL, "C");
+
     writeStr(fp, "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>");
     writeStr(fp, "<gpx xmlns=\"http://www.topografix.com/GPX/1/1\" version=\"1.1\" creator=\"", false);
     writeStr(fp, gpxm->creator.c_str(), false);
@@ -1122,5 +1124,8 @@ GPX_model::retCode_e GPXFile::save(ofstream* fp, const GPX_model* gpxm)
     }
     writeExtensions(fp, 1, &gpxm->extensions);
     writeStr(fp, "</gpx>");
+
+    setlocale(LC_ALL, "");
+
     return GPX_model::GPXM_OK;
 }

--- a/GPXLab/gpx_model/nmeafile.cpp
+++ b/GPXLab/gpx_model/nmeafile.cpp
@@ -61,7 +61,7 @@ static void copy_value(char *dst, const char *src, int maxsize)
 static double parse_position(const char *value)
 {
     int degrees = atoi(value) / 100;
-    double decimal = (UTILS_atof(value) - (degrees * 100)) / 60.0f;
+    double decimal = (atof(value) - (degrees * 100)) / 60.0f;
     return degrees + decimal;
 }
 
@@ -169,16 +169,16 @@ static int parseNMEA(GPX_wptType *pWp, const char *pNmea)
 
         // horizontal dilution of position
         p = strchr(p, ',') + 1;
-        pWp->hdop = (float)UTILS_atof(p);
+        pWp->hdop = (float)atof(p);
 
         // altitude
         p = strchr(p, ',') + 1;
-        pWp->altitude = UTILS_atof(p) ;
+        pWp->altitude = atof(p) ;
         p = strchr(p, ',') + 1;
 
         // height of geoid
         p = strchr(p, ',') + 1;
-        pWp->geoidheight = (float)UTILS_atof(p);
+        pWp->geoidheight = (float)atof(p);
         p = strchr(p, ',') + 1;
 
         return 1;
@@ -232,11 +232,11 @@ static int parseNMEA(GPX_wptType *pWp, const char *pNmea)
 
         // speed
         p = strchr(p, ',') + 1;
-        pWp->speed = (float)UTILS_atof(p) * 1.852f; // knots -> km/h
+        pWp->speed = (float)atof(p) * 1.852f; // knots -> km/h
 
         // angle
         p = strchr(p, ',') + 1;
-        pWp->heading = (float)UTILS_atof(p);
+        pWp->heading = (float)atof(p);
 
         // date
         hasDate = true;

--- a/GPXLab/gpx_model/utils.c
+++ b/GPXLab/gpx_model/utils.c
@@ -29,6 +29,7 @@ void UTILS_setenv(const char *name, const char *value)
   #else
     setenv(name, value, 1);
   #endif
+    setlocale(LC_ALL, "C");
 }
 
 void UTILS_unsetenv(const char *name)
@@ -40,13 +41,5 @@ void UTILS_unsetenv(const char *name)
   #else
     unsetenv(name);
   #endif
-}
-
-double UTILS_atof(const char *str)
-{
-    double val;
-    setlocale(LC_NUMERIC, "C");
-    val = atof(str);
-    setlocale(LC_NUMERIC, "");
-    return val;
+    setlocale(LC_ALL, "");
 }

--- a/GPXLab/gpx_model/utils.h
+++ b/GPXLab/gpx_model/utils.h
@@ -35,13 +35,6 @@ void UTILS_setenv(const char *name, const char *value);
  */
 void UTILS_unsetenv(const char *name);
 
-/**
- * @brief Converts a string to a double
- * @param str String
- * @return Double value
- */
-double UTILS_atof(const char *str);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
My system locale is non-English, so when I tried to save a file as GPX, I got a malformed one:
```xml
      ...
      <trkpt lat="60,249508834" lon="29,574680831">
        <ele>51,320000</ele>
        <time>2018-09-08T06:39:22Z</time>
      </trkpt>
      ...
```
That's because `sprintf` uses a decimal separator ('.' or ',') defined by the current locale.

So we need:
1. `setlocale(LC_ALL, "C")` - set minimal "C" locale before writing GPX file
2. `setlocale(LC_ALL, "")` - restore environment's default locale afterwards