### PR TITLE
Increase OSM max zoom to 19

### DIFF
--- a/QMapControl/osmmapadapter.cpp
+++ b/QMapControl/osmmapadapter.cpp
@@ -27,7 +27,7 @@
 namespace qmapcontrol
 {
     OSMMapAdapter::OSMMapAdapter()
-            : TileMapAdapter("tile.openstreetmap.org", "/%1/%2/%3.png", 256, 0, 17)
+            : TileMapAdapter("tile.openstreetmap.org", "/%1/%2/%3.png", 256, 0, 19)
     {
     }
 


### PR DESCRIPTION
Current max zoom is 17, but often more detail is needed and [OSM provides tiles up to 19](https://wiki.openstreetmap.org/wiki/Zoom_levels).