### PR TITLE
Fix app data location

### DIFF
--- a/GPXLab/dialogs/dialog_srtm.cpp
+++ b/GPXLab/dialogs/dialog_srtm.cpp
@@ -25,7 +25,7 @@ Dialog_srtm::Dialog_srtm(const GPX_wrapper *gpxmw, QWidget *parent) :
     gpxmw(gpxmw)
 {
     // create new SRTM class
-    QString dir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     srtm = new SRTM();
     srtm->setDirectory(dir.toStdString());
     QDir tempDir;


### PR DESCRIPTION
> Actually. `~/.config` (`QStandardPaths::AppConfigLocation`) directory is not a proper place for HGT files, it should be `~/.local/share` (`QStandardPaths::AppDataLocation`). See [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for more details.

_Originally posted by @sikmir in https://github.com/BourgeoisLab/GPXLab/issues/10#issuecomment-524898059_