### PR TITLE
Added support for "make install" on UNIX systems

### DIFF
--- a/GPXLab/GPXLab.pro
+++ b/GPXLab/GPXLab.pro
@@ -4,7 +4,13 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 greaterThan(QT_MAJOR_VERSION, 4): cache()
 
 ORGANISATION = BourgeoisLab
-TARGET = GPXLab
+unix:!macx {
+    ORGANISATION = bourgeoislab
+    TARGET = gpxlab
+} else {
+    ORGANISATION = BourgeoisLab
+    TARGET = GPXLab
+}
 VERSION = 0.7.0
 TEMPLATE = app
 
@@ -132,7 +138,23 @@ macx {
     ICON = ../pkg/gpxlab.icns
     QMAKE_INFO_PLIST = ../pkg/Info.plist
     LOCALE.path = Contents/Resources/translations
-    LOCALE.files = locale/gpxlab_fi.qm \
-                   locale/gpxlab_ru.qm
+    LOCALE.files = locale/*.qm
     QMAKE_BUNDLE_DATA += LOCALE
+}
+
+unix:!macx {
+    isEmpty(PREFIX):PREFIX = /usr/local
+    DEFINES += PREFIX=\\\"$$PREFIX\\\"
+
+    TARGET.path = $$PREFIX/bin
+    TARGET.files = ../bin/gpxlab
+    LOCALE.path = $$PREFIX/share/bourgeoislab/gpxlab/translations
+    LOCALE.files = locale/*.qm
+    ICON.path = $$PREFIX/share/pixmaps
+    ICON.files = ../doc/gpxlab.png
+    DESKTOP.path = $$PREFIX/share/applications
+    DESKTOP.files = ../pkg/gpxlab.desktop
+    MIME.path = $$PREFIX/share/mime/packages
+    MIME.files = ../pkg/gpxlab.xml
+    INSTALLS += TARGET LOCALE ICON DESKTOP MIME
 }

--- a/GPXLab/GPXLab.pro
+++ b/GPXLab/GPXLab.pro
@@ -3,7 +3,6 @@ QT += core gui network
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 greaterThan(QT_MAJOR_VERSION, 4): cache()
 
-ORGANISATION = BourgeoisLab
 unix:!macx {
     ORGANISATION = bourgeoislab
     TARGET = gpxlab

--- a/GPXLab/main.cpp
+++ b/GPXLab/main.cpp
@@ -19,14 +19,9 @@
 #include <QApplication>
 #include <QLibraryInfo>
 #include <QTranslator>
+#include <QStandardPaths>
 
-#if defined(Q_OS_WIN32)
-# define TRANSLATIONS_DIR QApplication::applicationDirPath() + QString("/translations")
-#elif defined(Q_OS_MAC)
-# define TRANSLATIONS_DIR QApplication::applicationDirPath() + QString("/../Resources/translations")
-#else
-# define TRANSLATIONS_DIR QString("/usr/share/gpxlab/translations")
-#endif
+#define TRANSLATIONS_DIR QStandardPaths::locate(QStandardPaths::AppDataLocation, "translations", QStandardPaths::LocateDirectory)
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Changes:
* CamelCase is normally not used on Linux/Unix systems. According to File Naming Conventions in Linux file names should be in lower case.
* Got rid of hardcoded path: `/usr/share/gpxlab/translations` (and the patch [gpxlab-0.6.0.patchset](https://github.com/haikuports/haikuports/blob/master/sci-geosciences/gpxlab/patches/gpxlab-0.6.0.patchset) is not needed as well)
* Added support for "make install" on UNIX systems:
```sh
$ qmake PREFIX=/custom/prefix/path GPXLab.pro
$ make INSTALL_ROOT=/where/install/to install
```