### PR TITLE
Fix settings dialog

### DIFF
--- a/GPXLab/dialogs/dialog_settings.cpp
+++ b/GPXLab/dialogs/dialog_settings.cpp
@@ -40,23 +40,24 @@ Dialog_settings::~Dialog_settings()
     delete ui;
 }
 
+void Dialog_settings::on_Dialog_settings_accepted()
+{
+    settings->doPersistentCaching = ui->checkBoxMapPersistentCache->isChecked();
+    settings->cachePath = ui->lineEditMapCachePath->text();
+    settings->autoLoadLastFile = ui->checkBoxAutoload->isChecked();
+}
+
 void Dialog_settings::on_checkBoxMapPersistentCache_toggled(bool checked)
 {
-    settings->doPersistentCaching = checked;
-    ui->pushButtonMapClearCache->setEnabled(settings->doPersistentCaching);
-    ui->lineEditMapCachePath->setEnabled(settings->doPersistentCaching);
-    ui->pushButtonMapCacheLocationSelect->setEnabled(settings->doPersistentCaching);
-    ui->pushButtonMapCacheLocationDefault->setEnabled(settings->doPersistentCaching);
+    ui->pushButtonMapClearCache->setEnabled(checked);
+    ui->lineEditMapCachePath->setEnabled(checked);
+    ui->pushButtonMapCacheLocationSelect->setEnabled(checked);
+    ui->pushButtonMapCacheLocationDefault->setEnabled(checked);
 }
 
 void Dialog_settings::on_pushButtonMapClearCache_clicked()
 {
     settings->clearCache();
-}
-
-void Dialog_settings::on_lineEditMapCachePath_editingFinished()
-{
-    settings->cachePath = ui->lineEditMapCachePath->text();
 }
 
 void Dialog_settings::on_pushButtonMapCacheLocationSelect_clicked()
@@ -65,17 +66,10 @@ void Dialog_settings::on_pushButtonMapCacheLocationSelect_clicked()
     if (!path.isEmpty())
     {
         ui->lineEditMapCachePath->setText(path);
-        on_lineEditMapCachePath_editingFinished();
     }
 }
 
 void Dialog_settings::on_pushButtonMapCacheLocationDefault_clicked()
 {
     ui->lineEditMapCachePath->setText(settings->defaultCachePath());
-    on_lineEditMapCachePath_editingFinished();
-}
-
-void Dialog_settings::on_checkBoxAutoload_toggled(bool checked)
-{
-    settings->autoLoadLastFile = checked;
 }

--- a/GPXLab/dialogs/dialog_settings.h
+++ b/GPXLab/dialogs/dialog_settings.h
@@ -56,12 +56,11 @@ public:
 
 private slots:
 
+    void on_Dialog_settings_accepted();
     void on_checkBoxMapPersistentCache_toggled(bool checked);
-    void on_lineEditMapCachePath_editingFinished();
     void on_pushButtonMapCacheLocationSelect_clicked();
     void on_pushButtonMapClearCache_clicked();
     void on_pushButtonMapCacheLocationDefault_clicked();
-    void on_checkBoxAutoload_toggled(bool checked);
 
 private:
 

--- a/GPXLab/dialogs/dialog_settings.ui
+++ b/GPXLab/dialogs/dialog_settings.ui
@@ -42,7 +42,7 @@
     <enum>Qt::Horizontal</enum>
    </property>
    <property name="standardButtons">
-    <set>QDialogButtonBox::Ok</set>
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
    </property>
    <property name="centerButtons">
     <bool>true</bool>


### PR DESCRIPTION
Make it possible to cancel settings dialog without saving changes.

### Actual behaviour
1. Open Settings dialog
2. Make some changes
3. Close Settings dialog without pressing "OK" button
4. Changes saved.

### Expected behaviour
1. Open Settings dialog
2. Make some changes
3. Close Settings dialog without pressing "OK" button (or by pressing "Cancel" button)
4. Changes skipped.
