### PR TITLE
Add tiles URL setting

### DIFF
--- a/GPXLab/dialogs/dialog_settings.cpp
+++ b/GPXLab/dialogs/dialog_settings.cpp
@@ -28,6 +28,7 @@ Dialog_settings::Dialog_settings(Settings *settings, QWidget *parent) :
 
     ui->checkBoxMapPersistentCache->setChecked(settings->doPersistentCaching);
     ui->lineEditMapCachePath->setText(settings->cachePath);
+    ui->lineEditTilesURL->setText(settings->tilesURL);
     ui->pushButtonMapClearCache->setEnabled(settings->doPersistentCaching);
     ui->lineEditMapCachePath->setEnabled(settings->doPersistentCaching);
     ui->pushButtonMapCacheLocationSelect->setEnabled(settings->doPersistentCaching);
@@ -45,6 +46,9 @@ void Dialog_settings::on_Dialog_settings_accepted()
     settings->doPersistentCaching = ui->checkBoxMapPersistentCache->isChecked();
     settings->cachePath = ui->lineEditMapCachePath->text();
     settings->autoLoadLastFile = ui->checkBoxAutoload->isChecked();
+    settings->tilesURL = ui->lineEditTilesURL->text();
+
+    settings->save();
 }
 
 void Dialog_settings::on_checkBoxMapPersistentCache_toggled(bool checked)
@@ -72,4 +76,9 @@ void Dialog_settings::on_pushButtonMapCacheLocationSelect_clicked()
 void Dialog_settings::on_pushButtonMapCacheLocationDefault_clicked()
 {
     ui->lineEditMapCachePath->setText(settings->defaultCachePath());
+}
+
+void Dialog_settings::on_pushButtonTilesURLDefault_clicked()
+{
+    ui->lineEditTilesURL->setText(settings->defaultTilesURL());
 }

--- a/GPXLab/dialogs/dialog_settings.h
+++ b/GPXLab/dialogs/dialog_settings.h
@@ -61,6 +61,7 @@ private slots:
     void on_pushButtonMapCacheLocationSelect_clicked();
     void on_pushButtonMapClearCache_clicked();
     void on_pushButtonMapCacheLocationDefault_clicked();
+    void on_pushButtonTilesURLDefault_clicked();
 
 private:
 

--- a/GPXLab/dialogs/dialog_settings.ui
+++ b/GPXLab/dialogs/dialog_settings.ui
@@ -181,6 +181,49 @@
      <item row="3" column="1">
       <widget class="QCheckBox" name="checkBoxAutoload"/>
      </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Tiles URL:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLineEdit" name="lineEditTilesURL">
+         <property name="toolTip">
+          <string>Placeholders to be used inside "Path" definition: %1 = zoom; %2 = x; %3 = y</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonTilesURLDefault">
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Default</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
     </layout>
    </widget>
   </widget>

--- a/GPXLab/gpxlab.cpp
+++ b/GPXLab/gpxlab.cpp
@@ -85,10 +85,11 @@ GPXLab::GPXLab(const QString &fileName, QWidget *parent) :
     connect(ui->treeTracks, SIGNAL(itemDoubleClicked(QTreeWidgetItem* , int)), this, SLOT(tree_doubleClicked(QTreeWidgetItem*, int)));
 
     // map widget
-    ui->mapWidget->init(gpxmw, undoStack, settings->doPersistentCaching, settings->cachePath);
+    ui->mapWidget->init(gpxmw, undoStack, settings->doPersistentCaching, settings->cachePath, settings->tilesURL);
     ui->mapWidget->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->mapWidget, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(map_showContextMenu(const QPoint&)));
     connect(ui->mapWidget, SIGNAL(viewChanged(const QPointF&, int)), this, SLOT(map_viewChanged(const QPointF&, int)));
+    connect(settings, SIGNAL(settingsChanged(bool)), ui->mapWidget, SLOT(settingsChanged(bool)));
 
     // calendar widget
     ui->calendarWidget->init(gpxmw);

--- a/GPXLab/locale/gpxlab_fi.ts
+++ b/GPXLab/locale/gpxlab_fi.ts
@@ -296,6 +296,7 @@
     </message>
     <message>
         <location filename="../dialogs/dialog_settings.ui" line="136"/>
+        <location filename="../dialogs/dialog_settings.ui" line="221"/>
         <source>Default</source>
         <translation>Oletusarvo</translation>
     </message>
@@ -310,7 +311,17 @@
         <translation>Automaattisesti lataa viimeinen tiedosto:</translation>
     </message>
     <message>
-        <location filename="../dialogs/dialog_settings.cpp" line="64"/>
+        <location filename="../dialogs/dialog_settings.ui" line="193"/>
+        <source>Tiles URL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/dialog_settings.ui" line="202"/>
+        <source>Placeholders to be used inside &quot;Path&quot; definition: %1 = zoom; %2 = x; %3 = y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/dialog_settings.cpp" line="69"/>
         <source>Cache Location</source>
         <translation>Välimuistin sijainti</translation>
     </message>
@@ -618,7 +629,7 @@
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="855"/>
+        <location filename="../gpxlab.cpp" line="856"/>
         <source>Tracks</source>
         <extracomment>NOM</extracomment>
         <translation>Jäljet</translation>
@@ -779,7 +790,7 @@
     </message>
     <message>
         <location filename="../gpxlab.ui" line="1220"/>
-        <location filename="../gpxlab.cpp" line="209"/>
+        <location filename="../gpxlab.cpp" line="210"/>
         <source>Open File</source>
         <translation>Avaa tiedosto</translation>
     </message>
@@ -790,7 +801,7 @@
     </message>
     <message>
         <location filename="../gpxlab.ui" line="1238"/>
-        <location filename="../gpxlab.cpp" line="261"/>
+        <location filename="../gpxlab.cpp" line="262"/>
         <source>Append Files</source>
         <translation>Lisää tiedostoja</translation>
     </message>
@@ -801,7 +812,7 @@
     </message>
     <message>
         <location filename="../gpxlab.ui" line="1253"/>
-        <location filename="../gpxlab.cpp" line="287"/>
+        <location filename="../gpxlab.cpp" line="288"/>
         <source>Save File</source>
         <translation>Tallenna tiedosto</translation>
     </message>
@@ -998,103 +1009,103 @@
         <translation>&amp;Tee uudelleen</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="227"/>
+        <location filename="../gpxlab.cpp" line="228"/>
         <source>Loading file: </source>
         <translation>Ladataan tiedostoa: </translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="247"/>
+        <location filename="../gpxlab.cpp" line="248"/>
         <source>Failed to open &quot;</source>
         <translation>Avaus epäonnistui: &quot;</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="274"/>
+        <location filename="../gpxlab.cpp" line="275"/>
         <source>Appending file: </source>
         <translation>Tiedoston lisääminen: </translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="291"/>
+        <location filename="../gpxlab.cpp" line="292"/>
         <source>Saving file: </source>
         <translation>Tiedoston tallentaminen: </translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="306"/>
+        <location filename="../gpxlab.cpp" line="307"/>
         <source>Failed to save &quot;</source>
         <translation>Tallennus epäonnistui: &quot;</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="401"/>
-        <location filename="../gpxlab.cpp" line="434"/>
+        <location filename="../gpxlab.cpp" line="402"/>
+        <location filename="../gpxlab.cpp" line="435"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="402"/>
-        <location filename="../gpxlab.cpp" line="435"/>
+        <location filename="../gpxlab.cpp" line="403"/>
+        <location filename="../gpxlab.cpp" line="436"/>
         <source>km/h</source>
         <translation>km/t</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="403"/>
-        <location filename="../gpxlab.cpp" line="436"/>
+        <location filename="../gpxlab.cpp" line="404"/>
+        <location filename="../gpxlab.cpp" line="437"/>
         <source>min/km</source>
         <translation>min/km</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="404"/>
         <location filename="../gpxlab.cpp" line="405"/>
-        <location filename="../gpxlab.cpp" line="437"/>
+        <location filename="../gpxlab.cpp" line="406"/>
         <location filename="../gpxlab.cpp" line="438"/>
         <location filename="../gpxlab.cpp" line="439"/>
         <location filename="../gpxlab.cpp" line="440"/>
+        <location filename="../gpxlab.cpp" line="441"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="466"/>
-        <location filename="../gpxlab.cpp" line="521"/>
+        <location filename="../gpxlab.cpp" line="467"/>
+        <location filename="../gpxlab.cpp" line="522"/>
         <source>Updating file properties...</source>
         <translation>Tiedoston ominaisuuksien päivittäminen...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="470"/>
-        <location filename="../gpxlab.cpp" line="529"/>
+        <location filename="../gpxlab.cpp" line="471"/>
+        <location filename="../gpxlab.cpp" line="530"/>
         <source>Generating track tree...</source>
         <translation>Generoidaan puu...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="474"/>
+        <location filename="../gpxlab.cpp" line="475"/>
         <source>Generating map...</source>
         <translation>Generoidaan kartta...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="478"/>
-        <location filename="../gpxlab.cpp" line="534"/>
+        <location filename="../gpxlab.cpp" line="479"/>
+        <location filename="../gpxlab.cpp" line="535"/>
         <source>Generating track calendar...</source>
         <translation>Generoidaan kalenteri...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="525"/>
+        <location filename="../gpxlab.cpp" line="526"/>
         <source>Updating track properties...</source>
         <translation>Jäljen ominaisuuksien päivittäminen...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="539"/>
+        <location filename="../gpxlab.cpp" line="540"/>
         <source>Generating diagram...</source>
         <translation>Generoidaan kaaviokuva...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="543"/>
+        <location filename="../gpxlab.cpp" line="544"/>
         <source>Generating point list...</source>
         <translation>Generoidaan pistelista...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="929"/>
+        <location filename="../gpxlab.cpp" line="930"/>
         <source>The file has been modified.</source>
         <translation>Tiedosto on muutettu.</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="930"/>
+        <location filename="../gpxlab.cpp" line="931"/>
         <source>Do you want to save your changes?</source>
         <translation>Haluatko tallentaa muutokset?</translation>
     </message>
@@ -1323,7 +1334,7 @@ ID</translation>
 <context>
     <name>QMapWidget</name>
     <message>
-        <location filename="../widgets/qmapwidget.cpp" line="313"/>
+        <location filename="../widgets/qmapwidget.cpp" line="327"/>
         <source>km</source>
         <translation>km</translation>
     </message>

--- a/GPXLab/locale/gpxlab_ru.ts
+++ b/GPXLab/locale/gpxlab_ru.ts
@@ -296,6 +296,7 @@
     </message>
     <message>
         <location filename="../dialogs/dialog_settings.ui" line="136"/>
+        <location filename="../dialogs/dialog_settings.ui" line="221"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
@@ -310,7 +311,17 @@
         <translation>Автозагружать последний файл:</translation>
     </message>
     <message>
-        <location filename="../dialogs/dialog_settings.cpp" line="64"/>
+        <location filename="../dialogs/dialog_settings.ui" line="193"/>
+        <source>Tiles URL:</source>
+        <translation>URL тайлов:</translation>
+    </message>
+    <message>
+        <location filename="../dialogs/dialog_settings.ui" line="202"/>
+        <source>Placeholders to be used inside &quot;Path&quot; definition: %1 = zoom; %2 = x; %3 = y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../dialogs/dialog_settings.cpp" line="69"/>
         <source>Cache Location</source>
         <translation>Расположение кэша</translation>
     </message>
@@ -618,7 +629,7 @@
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="855"/>
+        <location filename="../gpxlab.cpp" line="856"/>
         <source>Tracks</source>
         <extracomment>NOM</extracomment>
         <translation>Треки</translation>
@@ -779,7 +790,7 @@
     </message>
     <message>
         <location filename="../gpxlab.ui" line="1220"/>
-        <location filename="../gpxlab.cpp" line="209"/>
+        <location filename="../gpxlab.cpp" line="210"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
@@ -790,7 +801,7 @@
     </message>
     <message>
         <location filename="../gpxlab.ui" line="1238"/>
-        <location filename="../gpxlab.cpp" line="261"/>
+        <location filename="../gpxlab.cpp" line="262"/>
         <source>Append Files</source>
         <translation>Добавить файлы</translation>
     </message>
@@ -801,7 +812,7 @@
     </message>
     <message>
         <location filename="../gpxlab.ui" line="1253"/>
-        <location filename="../gpxlab.cpp" line="287"/>
+        <location filename="../gpxlab.cpp" line="288"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
@@ -998,103 +1009,103 @@
         <translation>&amp;Вернуть</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="227"/>
+        <location filename="../gpxlab.cpp" line="228"/>
         <source>Loading file: </source>
         <translation>Загрузка файла: </translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="247"/>
+        <location filename="../gpxlab.cpp" line="248"/>
         <source>Failed to open &quot;</source>
         <translation>Не удалось открыть &quot;</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="274"/>
+        <location filename="../gpxlab.cpp" line="275"/>
         <source>Appending file: </source>
         <translation>Добавление файла: </translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="291"/>
+        <location filename="../gpxlab.cpp" line="292"/>
         <source>Saving file: </source>
         <translation>Сохранение файла: </translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="306"/>
+        <location filename="../gpxlab.cpp" line="307"/>
         <source>Failed to save &quot;</source>
         <translation>Не удалось сохранить &quot;</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="401"/>
-        <location filename="../gpxlab.cpp" line="434"/>
+        <location filename="../gpxlab.cpp" line="402"/>
+        <location filename="../gpxlab.cpp" line="435"/>
         <source>km</source>
         <translation>км</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="402"/>
-        <location filename="../gpxlab.cpp" line="435"/>
+        <location filename="../gpxlab.cpp" line="403"/>
+        <location filename="../gpxlab.cpp" line="436"/>
         <source>km/h</source>
         <translation>км/ч</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="403"/>
-        <location filename="../gpxlab.cpp" line="436"/>
+        <location filename="../gpxlab.cpp" line="404"/>
+        <location filename="../gpxlab.cpp" line="437"/>
         <source>min/km</source>
         <translation>мин/км</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="404"/>
         <location filename="../gpxlab.cpp" line="405"/>
-        <location filename="../gpxlab.cpp" line="437"/>
+        <location filename="../gpxlab.cpp" line="406"/>
         <location filename="../gpxlab.cpp" line="438"/>
         <location filename="../gpxlab.cpp" line="439"/>
         <location filename="../gpxlab.cpp" line="440"/>
+        <location filename="../gpxlab.cpp" line="441"/>
         <source>m</source>
         <translation>м</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="466"/>
-        <location filename="../gpxlab.cpp" line="521"/>
+        <location filename="../gpxlab.cpp" line="467"/>
+        <location filename="../gpxlab.cpp" line="522"/>
         <source>Updating file properties...</source>
         <translation>Обновление свойств файла...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="470"/>
-        <location filename="../gpxlab.cpp" line="529"/>
+        <location filename="../gpxlab.cpp" line="471"/>
+        <location filename="../gpxlab.cpp" line="530"/>
         <source>Generating track tree...</source>
         <translation>Генерация дерева треков...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="474"/>
+        <location filename="../gpxlab.cpp" line="475"/>
         <source>Generating map...</source>
         <translation>Генерация карты...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="478"/>
-        <location filename="../gpxlab.cpp" line="534"/>
+        <location filename="../gpxlab.cpp" line="479"/>
+        <location filename="../gpxlab.cpp" line="535"/>
         <source>Generating track calendar...</source>
         <translation>Генерация календаря треков...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="525"/>
+        <location filename="../gpxlab.cpp" line="526"/>
         <source>Updating track properties...</source>
         <translation>Обновление свойств трека...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="539"/>
+        <location filename="../gpxlab.cpp" line="540"/>
         <source>Generating diagram...</source>
         <translation>Генерация диаграммы...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="543"/>
+        <location filename="../gpxlab.cpp" line="544"/>
         <source>Generating point list...</source>
         <translation>Генерация списка точек...</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="929"/>
+        <location filename="../gpxlab.cpp" line="930"/>
         <source>The file has been modified.</source>
         <translation>Файл был изменен.</translation>
     </message>
     <message>
-        <location filename="../gpxlab.cpp" line="930"/>
+        <location filename="../gpxlab.cpp" line="931"/>
         <source>Do you want to save your changes?</source>
         <translation>Хотите ли вы сохранить свои изменения?</translation>
     </message>
@@ -1324,7 +1335,7 @@ ID</translation>
 <context>
     <name>QMapWidget</name>
     <message>
-        <location filename="../widgets/qmapwidget.cpp" line="313"/>
+        <location filename="../widgets/qmapwidget.cpp" line="327"/>
         <source>km</source>
         <translation>км</translation>
     </message>

--- a/GPXLab/settings.cpp
+++ b/GPXLab/settings.cpp
@@ -38,9 +38,12 @@ void Settings::load()
     recentFiles = qsettings.value("recentFileList").toStringList();
     doPersistentCaching = qsettings.value("doPersistentCaching", true).toBool();
     cachePath = qsettings.value("cachePath", "").toString();
+    tilesURL = qsettings.value("tilesURL", "").toString();
     if (cachePath.isEmpty())
         cachePath = defaultCachePath();
     autoLoadLastFile = qsettings.value("autoLoadLastFile", true).toBool();
+    if (tilesURL.isEmpty())
+        tilesURL = defaultTilesURL();
     emit settingsChanged(true);
 }
 
@@ -53,6 +56,7 @@ void Settings::save()
     qsettings.setValue("doPersistentCaching", doPersistentCaching);
     qsettings.setValue("cachePath", cachePath);
     qsettings.setValue("autoLoadLastFile", autoLoadLastFile);
+    qsettings.setValue("tilesURL", tilesURL);
     emit settingsChanged(false);
 }
 
@@ -112,4 +116,9 @@ void Settings::clearCache()
 QString Settings::defaultCachePath()
 {
     return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+}
+
+QString Settings::defaultTilesURL()
+{
+    return QString("http://tile.openstreetmap.org/%1/%2/%3.png");
 }

--- a/GPXLab/settings.h
+++ b/GPXLab/settings.h
@@ -100,6 +100,12 @@ public:
     QString defaultCachePath();
 
     /**
+     * @brief Returns the default tiles URL
+     * @return Default tiles URL
+     */
+    QString defaultTilesURL();
+
+    /**
      * @brief Maximal number of undo commands stored
      */
     const int undoLimit;
@@ -128,6 +134,11 @@ public:
      * @brief Loads the last opened file on startup
      */
     bool autoLoadLastFile;
+
+    /**
+     * @brief Tiles URL
+     */
+    QString tilesURL;
 
 signals:
 

--- a/GPXLab/widgets/qmapwidget.h
+++ b/GPXLab/widgets/qmapwidget.h
@@ -64,8 +64,9 @@ public:
      * @param undoStack Undo stack
      * @param doPersistentCaching Enable / disable persistent caching
      * @param cachePath Path to the cache directory
+     * @param tilesURL Tiles URL
      */
-    void init(GPX_wrapper *gpxmw, QUndoStack *undoStack, bool doPersistentCaching, QString &cachePath);
+    void init(GPX_wrapper *gpxmw, QUndoStack *undoStack, bool doPersistentCaching, QString &cachePath, QString &tilesURL);
 
     /**
      * @brief Generates the map according to the GPX_Model
@@ -187,6 +188,11 @@ private slots:
      */
     void mouseEventCoordinate(const QMouseEvent* evnt, const QPointF coordinate);
 
+    /**
+     * @brief Slot when settings are loaded or saved
+     */
+    void settingsChanged(bool loaded);
+
 private:
 
     /**
@@ -201,6 +207,8 @@ private:
     void keyPressEvent(QKeyEvent *event);
 
     void leaveEvent(QEvent *event);
+
+    void setTilesURL(const QString &tilesURL);
 
 private:
     GPX_wrapper *gpxmw;

--- a/QMapControl/bingapimapadapter.cpp
+++ b/QMapControl/bingapimapadapter.cpp
@@ -39,7 +39,7 @@
 namespace qmapcontrol
 {
     bingApiMapadapter::bingApiMapadapter(QString mapType, QString apiKey)
-    : TileMapAdapter("dev.virtualearth.net", "/REST/v1/Imagery/Map/", 256, 0, 21),
+    : TileMapAdapter("http://dev.virtualearth.net", "/REST/v1/Imagery/Map/", 256, 0, 21),
       myKey(apiKey),
       myMapType(mapType)
     {

--- a/QMapControl/googleapimapadapter.cpp
+++ b/QMapControl/googleapimapadapter.cpp
@@ -40,7 +40,7 @@
 namespace qmapcontrol
 {
     googleApiMapadapter::googleApiMapadapter(layerType qMapType, apiType qApiType, QString qApiKey, QString qApiClientID, QString qServerAddress)
-    : TileMapAdapter(qServerAddress, "/maps/api/staticmap?", 256, 1, 22),
+    : TileMapAdapter("http://" + qServerAddress, "/maps/api/staticmap?", 256, 1, 22),
       mApiKey(qApiKey),
       mApiClientID(qApiClientID),
       mApiType( qApiType )

--- a/QMapControl/googlemapadapter.cpp
+++ b/QMapControl/googlemapadapter.cpp
@@ -27,7 +27,7 @@
 namespace qmapcontrol
 {
     GoogleMapAdapter::GoogleMapAdapter( googleLayerType qLayerType )
-        : TileMapAdapter("mt1.google.com", "/vt/v=ap.106&hl=en&x=%2&y=%3&zoom=%1&lyrs=" + typeToString(qLayerType), 256, 17, 0)
+        : TileMapAdapter("http://mt1.google.com", "/vt/v=ap.106&hl=en&x=%2&y=%3&zoom=%1&lyrs=" + typeToString(qLayerType), 256, 17, 0)
             //: TileMapAdapter("tile.openstreetmap.org", "/%1/%2/%3.png", 256, 0, 17)
     {
         QString layerType = typeToString( qLayerType );

--- a/QMapControl/mapnetwork.cpp
+++ b/QMapControl/mapnetwork.cpp
@@ -61,20 +61,7 @@ namespace qmapcontrol
 
     void MapNetwork::loadImage(const QString& host, const QString& url)
     {
-        QString hostName = host;
-        QString portNumber = QString("80");
-
-        QRegExp r(".:.");
-
-        if(r.indexIn(host) >= 0)
-        {
-            QStringList s = host.split(":");
-
-            hostName = s.at(0);
-            portNumber = s.at(1);
-        }
-
-        QString finalUrl = QString("http://%1:%2%3").arg(hostName).arg(portNumber).arg(url);
+        QString finalUrl = QString("%1%2").arg(host).arg(url);
         QNetworkRequest request = QNetworkRequest(QUrl(finalUrl));
 
         if( cacheEnabled )
@@ -90,7 +77,7 @@ namespace qmapcontrol
         QMutexLocker lock(&vectorMutex);
         replyList.append( http->get(request) );
         loadingMap.insert( finalUrl, url );
-}
+    }
 
     void MapNetwork::requestFinished(QNetworkReply *reply)
     {

--- a/QMapControl/openaerialmapadapter.cpp
+++ b/QMapControl/openaerialmapadapter.cpp
@@ -27,7 +27,7 @@
 namespace qmapcontrol
 {
     OpenAerialMapAdapter::OpenAerialMapAdapter()
-            : TileMapAdapter("tile.openaerialmap.org", "/tiles/1.0.0/openaerialmap-900913/%1/%2/%3.png", 256, 0, 17)
+            : TileMapAdapter("http://tile.openaerialmap.org", "/tiles/1.0.0/openaerialmap-900913/%1/%2/%3.png", 256, 0, 17)
     {
     }
 

--- a/QMapControl/osmmapadapter.cpp
+++ b/QMapControl/osmmapadapter.cpp
@@ -27,7 +27,7 @@
 namespace qmapcontrol
 {
     OSMMapAdapter::OSMMapAdapter()
-            : TileMapAdapter("tile.openstreetmap.org", "/%1/%2/%3.png", 256, 0, 19)
+            : TileMapAdapter("http://tile.openstreetmap.org", "/%1/%2/%3.png", 256, 0, 19)
     {
     }
 

--- a/QMapControl/tilemapadapter.cpp
+++ b/QMapControl/tilemapadapter.cpp
@@ -30,7 +30,11 @@ namespace qmapcontrol
             :MapAdapter(host, serverPath, tilesize, minZoom, maxZoom)
     {
         PI = acos(-1.0);
+        parseParams(serverPath);
+    }
 
+    void TileMapAdapter::parseParams(const QString& serverPath)
+    {
         /*
             Initialize the "substring replace engine". First the string replacement
             in getQuery was made by QString().arg() but this was very slow. So this
@@ -153,6 +157,12 @@ namespace qmapcontrol
 
         return QPointF(longitude, latitude);
 
+    }
+
+    void TileMapAdapter::changeHostAddress(const QString qHost, const QString qServerPath)
+    {
+        MapAdapter::changeHostAddress(qHost, qServerPath);
+        parseParams(qServerPath);
     }
 
     bool TileMapAdapter::isTileValid(int x, int y, int z) const

--- a/QMapControl/tilemapadapter.h
+++ b/QMapControl/tilemapadapter.h
@@ -59,11 +59,15 @@ namespace qmapcontrol
         virtual QPoint coordinateToDisplay(const QPointF&) const;
         virtual QPointF displayToCoordinate(const QPoint&) const;
 
+        virtual void changeHostAddress(const QString qHost, const QString qServerPath = QString());
+
         qreal PI;
 
     protected:
         qreal rad_deg(qreal) const;
         qreal deg_rad(qreal) const;
+
+        void parseParams(const QString& serverPath);
 
         virtual bool isTileValid(int x, int y, int z) const;
         virtual void zoom_in();

--- a/QMapControl/wmsmapadapter.cpp
+++ b/QMapControl/wmsmapadapter.cpp
@@ -29,7 +29,7 @@
 namespace qmapcontrol
 {
     WMSMapAdapter::WMSMapAdapter(QString host, QString serverPath, int tilesize)
-            : MapAdapter(host, serverPath, tilesize, 0, 17)
+            : MapAdapter("http://" + host, serverPath, tilesize, 0, 17)
     {
         mNumberOfTiles = pow(2.0, mCurrent_zoom);
         coord_per_x_tile = 360. / mNumberOfTiles;

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Release Notes
 - [new] Use SRTM version 3.0 global 1 arc second data
 - [new] SRTM files must now be located in the QStandardPaths::AppDataLocation directory
 - [new] Settings to automatically reload the last opened file on startup
+- [new] Support arbitrary map provider (thanks to sikmir). Tested with:
+  - default: `http://tile.openstreetmap.org/%1/%2/%3.png`
+  - with query: `http://a.tile.thunderforest.com/cycle/%1/%2/%3.png?apikey=<my-api-key>`
+  - with https: `https://a.tile.opentopomap.org/%1/%2/%3.png`
+  - with explicit port: `https://a.tile.opentopomap.org:443/%1/%2/%3.png`
 
 **[v0.6.0]**
 - [new] Height files must now be placed in configuration direcotry


### PR DESCRIPTION
Make it possible to configure tiles URL instead of hardcoded one (`http://tile.openstreetmap.org/%1/%2/%3.png`).

Tested with:
1. default: `http://tile.openstreetmap.org/%1/%2/%3.png`
2. with query: `http://a.tile.thunderforest.com/cycle/%1/%2/%3.png?apikey=<my-api-key>`
3. with https: `https://a.tile.opentopomap.org/%1/%2/%3.png`
4. with explicit port: `https://a.tile.opentopomap.org:443/%1/%2/%3.png`

![scr1](https://user-images.githubusercontent.com/688044/65396045-865e0c00-ddaa-11e9-864e-ab6b37f93e44.jpg)
