### PR TITLE
The path to the last opened file is now stored in the options

### DIFF
--- a/GPXLab/gpxlab.cpp
+++ b/GPXLab/gpxlab.cpp
@@ -197,10 +197,8 @@ bool GPXLab::openFile(QString fileName)
 
     if (fileName.isEmpty())
     {
-        QString lastOpenedPath;
         QString selectedFilter;
-        lastOpenedPath = settings->getValue("lastOpenedPath").toString();
-        fileName = QFileDialog::getOpenFileName(this, tr("Open File"), lastOpenedPath, "GPX (*.gpx);;NMEA (*.txt *.nmea);; SpoQ (*.act *.xml)", &selectedFilter);
+        fileName = QFileDialog::getOpenFileName(this, tr("Open File"), settings->lastOpenedPath, "GPX (*.gpx);;NMEA (*.txt *.nmea);; SpoQ (*.act *.xml)", &selectedFilter);
         if (selectedFilter == "GPX (*.gpx)")
             fileType = GPX_model::GPXM_FILE_GPX;
         else if (selectedFilter == "NMEA (*.txt *.nmea)")
@@ -237,7 +235,8 @@ bool GPXLab::openFile(QString fileName)
             // store the file path
             QDir filePath = QFileInfo(fileName).absoluteDir();
             QString currentFilePath = filePath.absolutePath();
-            settings->setValue("lastOpenedPath", currentFilePath);
+            settings->lastOpenedPath = currentFilePath;
+
             retValue = true;
         }
         else

--- a/GPXLab/gpxlab.cpp
+++ b/GPXLab/gpxlab.cpp
@@ -197,8 +197,10 @@ bool GPXLab::openFile(QString fileName)
 
     if (fileName.isEmpty())
     {
+        QString lastOpenedPath;
         QString selectedFilter;
-        fileName = QFileDialog::getOpenFileName(this, tr("Open File"), "", "GPX (*.gpx);;NMEA (*.txt *.nmea);; SpoQ (*.act *.xml)", &selectedFilter);
+        lastOpenedPath = settings->getValue("lastOpenedPath").toString();
+        fileName = QFileDialog::getOpenFileName(this, tr("Open File"), lastOpenedPath, "GPX (*.gpx);;NMEA (*.txt *.nmea);; SpoQ (*.act *.xml)", &selectedFilter);
         if (selectedFilter == "GPX (*.gpx)")
             fileType = GPX_model::GPXM_FILE_GPX;
         else if (selectedFilter == "NMEA (*.txt *.nmea)")
@@ -232,6 +234,10 @@ bool GPXLab::openFile(QString fileName)
             // enable actions
             updateActions(true);   
 
+            // store the file path
+            QDir filePath = QFileInfo(fileName).absoluteDir();
+            QString currentFilePath = filePath.absolutePath();
+            settings->setValue("lastOpenedPath", currentFilePath);
             retValue = true;
         }
         else

--- a/GPXLab/settings.cpp
+++ b/GPXLab/settings.cpp
@@ -22,6 +22,7 @@ void Settings::load()
     doPersistentCaching = qsettings.value("doPersistentCaching", true).toBool();
     cachePath = qsettings.value("cachePath", "").toString();
     tilesURL = qsettings.value("tilesURL", "").toString();
+    lastOpenedPath = qsettings.value("lastOpenedFilePath", "").toString();
     if (cachePath.isEmpty())
         cachePath = defaultCachePath();
     autoLoadLastFile = qsettings.value("autoLoadLastFile", true).toBool();
@@ -45,6 +46,7 @@ void Settings::save()
     qsettings.setValue("checkUpdate", checkUpdate);
     qsettings.setValue("checkUpdateLastDate", checkUpdateLastDate);
     qsettings.setValue("tilesURL", tilesURL);
+    qsettings.setValue("lastOpenedPath", lastOpenedPath);
     emit settingsChanged(false);
 }
 

--- a/GPXLab/settings.h
+++ b/GPXLab/settings.h
@@ -135,6 +135,11 @@ public:
      */
     QString tilesURL;
 
+    /**
+     * @brief Last opened file path
+     */
+    QString lastOpenedPath;
+
 signals:
 
     /**


### PR DESCRIPTION
Hi.
This is a simple patch to store the path to the last opened file in the config options. 
The idea is that the user always download the GPX (and the other) file to the same directory, so he need to always navigate to it when opening a new file.
