### PR TITLE
Do not show the update available dialog on the first run

### DIFF
--- a/GPXLab/dialogs/dialog_checkupdate.cpp
+++ b/GPXLab/dialogs/dialog_checkupdate.cpp
@@ -69,6 +69,7 @@ bool Dialog_CheckUpdate::parseReplyGithub(const QByteArray& str)
     }
 
     QDate dtPublished = QDate::fromString(reply.object().value("published_at").toString(), Qt::ISODate);
+
     if (dtPublished > mDateSince)
     {
         QLocale locale = QLocale();

--- a/GPXLab/gpxlab.cpp
+++ b/GPXLab/gpxlab.cpp
@@ -354,6 +354,10 @@ void GPXLab::checkForUpdate(bool force)
     QDate since;
     if (!force)
         since = settings->checkUpdateLastDate;
+    if (since.isValid() == false) {
+        since = QDate::currentDate();
+        settings->checkUpdateLastDate = QDate::currentDate();
+    }
     Dialog_CheckUpdate *dlg = new Dialog_CheckUpdate(settings->checkUpdateUrl, since, this);
     connect(dlg, SIGNAL(finished()), this, SLOT(checkUpdateFinished()));
     dlg->checkForUpdate();


### PR DESCRIPTION
A little patch that should solve the issue #38 

It simply store the current date as `checkUpdateLastDate` if the one read from the settings is invalid (which is on the first run of the program)

It should cover all the use cases except if you download an older release (for example 0.6.0), in this case you would miss the current release (0.7.0), but I don't think this is a problem. 